### PR TITLE
feat: enable access via junifer.ext

### DIFF
--- a/changelog.d/5.added.md
+++ b/changelog.d/5.added.md
@@ -1,0 +1,1 @@
+Allow `junifer-data` to be accessed via `junifer` CLI

--- a/junifer_data/_cli.py
+++ b/junifer_data/_cli.py
@@ -35,7 +35,7 @@ def _set_log_config(verbose: int) -> None:
 
 
 @click.group
-@click.version_option()
+@click.version_option(prog_name="junifer-data")
 @click.help_option()
 def cli() -> None:  # pragma: no cover
     """junifer-data CLI client."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ packages = [
 ]
 
 [tool.setuptools_scm]
-version_scheme = "guess-next-dev"
+version_scheme = "only-version"
 local_scheme = "no-local-version"
 write_to = "junifer_data/_version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ Source = "https://github.com/juaml/junifer-data-client"
 [project.scripts]
 junifer-data = "junifer_data._cli:cli"
 
+[project.entry-points."junifer.ext"]
+data = "junifer_data._cli:cli"
+
 [project.optional-dependencies]
 dev = [
     "tox",


### PR DESCRIPTION
This PR allows `junifer-data` to be accessed via `junifer` command's `data` subcommand.